### PR TITLE
Updated documentation and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: cpp
+
+script: cmake
+
+compiler:
+ - clang
+ - gcc
+
+env:
+  global:
+    - GCC_VERSION="4.9"
+
+matrix:
+  exclude:
+    - compiler: gcc
+
+# Install dependencies
+before_install:
+  - export CHECKOUT_PATH=`pwd`;
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-${GCC_VERSION}; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
+
+  # Install libc++ if tests are run with clang++
+  - if [ "$CXX" == "clang++" ]; then export LIBCXX=On; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then svn co --quiet http://llvm.org/svn/llvm-project/libcxx/trunk libcxx; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd libcxx/lib && bash buildit; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo cp ./libc++.so.1.0 /usr/lib/; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo mkdir /usr/include/c++/v1; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd .. && sudo cp -r include/* /usr/include/c++/v1/; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd /usr/lib && sudo ln -sf libc++.so.1.0 libc++.so; fi
+  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo ln -sf libc++.so.1.0 libc++.so.1 && cd $cwd; fi
+
+install:
+  - cd $CHECKOUT_PATH
+  - if [ ! -d build ]; then mkdir build; fi
+  - cd build
+  - export CXX_FLAGS=""
+  - export CXX_LINKER_FLAGS=""
+  - if [ -z "$BUILD_TYPE" ]; then export BUILD_TYPE=Release; fi
+  - if [ "$CXX" == "clang++" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
+  - if [ -n "$LIBCXX" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
+  - if [ -n "$LIBCXX" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
+
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}"
+  - make VERBOSE=1
+
+script:
+  - ctest -VV
+
+notifications:
+  email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,14 @@ enable_testing()
 
 include_directories(include)
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -Wno-unused-function -ftemplate-backtrace-limit=0 -Wdocumentation")
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
+  set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -march=native -mtune=native -DNDEBUG")
+elseif(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -Wno-unused-function")
+endif()
+
 add_subdirectory(doc)
+add_subdirectory(example)
 add_subdirectory(test)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -9,12 +9,11 @@ STRIP_FROM_INC_PATH     = @Meta_SOURCE_DIR@/include
 ALIASES                 =
 ENABLED_SECTIONS        =
 
-ALIASES += "req=\xrefitem complexity \"Complexity\" \"Complexities\" "
-
 # Resources
 OUTPUT_DIRECTORY        =
 INPUT                   = @Meta_SOURCE_DIR@/include \
-                          @Meta_SOURCE_DIR@/doc/index.md
+                          @Meta_SOURCE_DIR@/doc/index.md \
+                          @Meta_SOURCE_DIR@/example/examples.hpp
 FILE_PATTERNS           = *.hpp *.md
 RECURSIVE               = YES
 EXCLUDE                 =
@@ -22,7 +21,8 @@ EXCLUDE_SYMBOLS         = detail
 EXAMPLE_PATH            = @Meta_SOURCE_DIR@/example \
                           @Meta_SOURCE_DIR@/test
 EXAMPLE_RECURSIVE       = YES
-IMAGE_PATH              = @Meta_BINARY_DIR@/image
+EXAMPLE_PATTERNS        = *.cpp 
+IMAGE_PATH              = 
 WARN_IF_UNDOCUMENTED    = NO
 
 SHOW_GROUPED_MEMB_INC   = YES
@@ -45,7 +45,6 @@ TYPEDEF_HIDES_STRUCT    = YES
 GENERATE_HTML           = YES
 GENERATE_LATEX          = NO
 
-
 GENERATE_TODOLIST       = YES
 GENERATE_TESTLIST       = YES
 GENERATE_BUGLIST        = YES
@@ -60,8 +59,8 @@ CLASS_DIAGRAMS          = YES
 HAVE_DOT                = NO
 
 HIDE_UNDOC_RELATIONS    = NO
-HIDE_UNDOC_MEMBERS      = NO
-HIDE_UNDOC_CLASSES      = NO
+HIDE_UNDOC_MEMBERS      = YES
+HIDE_UNDOC_CLASSES      = YES
 HIDE_FRIEND_COMPOUNDS   = NO
 HIDE_IN_BODY_DOCS       = NO
 INTERNAL_DOCS           = NO
@@ -86,13 +85,11 @@ EXPAND_ONLY_PREDEF      = NO
 SEARCH_INCLUDES         = YES
 INCLUDE_PATH            = @Meta_SOURCE_DIR@/include
 INCLUDE_FILE_PATTERNS   =
-PREDEFINED              = RANGES_DOXYGEN_INVOKED \
-                          CONCEPT_REQUIRES_IMPL_(X)=requires=X \
-                          "CONCEPT_REQUIRES_IMPL(X)=/// \pre X" \
+PREDEFINED              = META_DOXYGEN_INVOKED 
 SKIP_FUNCTION_MACROS    = NO
 
 # Source browsing
-SOURCE_BROWSER          = NO
+SOURCE_BROWSER          = YES
 INLINE_SOURCES          = NO
 STRIP_CODE_COMMENTS     = YES
 REFERENCED_BY_RELATION  = YES
@@ -128,5 +125,14 @@ SEARCHENGINE            = YES
 USE_MATHJAX             = NO
 MATHJAX_FORMAT          = HTML-CSS
 MATHJAX_RELPATH         = http://cdn.mathjax.org/mathjax/latest
-MATHJAX_EXTENSIONS      =
+MATHJAX_EXTENSIONS      = TeX/AMSmath TeX/AMSsymbols
 MATHJAX_CODEFILE        =
+
+# Misc
+CREATE_SUBDIRS          = NO
+SHORT_NAMES             = NO
+CASE_SENSE_NAMES        = YES
+QUIET                   = YES
+WARNINGS                = YES
+WARN_IF_DOC_ERROR       = YES
+

--- a/doc/index.md
+++ b/doc/index.md
@@ -3,38 +3,108 @@ User Manual       {#mainpage}
 
 \tableofcontents
 
-\section tutorial-preface Preface
-
 --------------------------------------------
-*Meta: a tiny metaprogramming library* is the evolution of a minimal useful set
-of primitives for manipulating lists of types introduced by Eric Niebler in
-[this blog post](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/)
-and used throught his
-[range-v3 library](https://github.com/ericniebler/range-v3).
+*Meta* is a C++14 tiny metaprogramming library developed by
+[Eric Niebler](https://github.com/ericniebler).
 
-All of the source code in this project was written by
-[Eric Niebler](https://github.com/ericniebler) as a set of utilities within his
-[range-v3 library](https://github.com/ericniebler/range-v3) and is under the
-Boost Software License (see the attached LICENSE.md) file.
-
-I have made some minor tweaks to the comments, examples, test, and
-documentation, and hopefully I haven't introduced any errors. If you find an
-error or a bug please fill an issue, these are probably mine.
-
-\subsection tutorial-installation Installation
-
---------------------------------------------
-This library is header-only. You can get its source code from its
-[github repository](https://github.com/gnzlbg/meta). To compile with
-meta, you have to:
+It is released under the Boost Software License and it is header only, that is,
+to compile with meta you just have to:
 
 ~~~~~~~{.cpp}
 #include <meta/meta.hpp>
 ~~~~~~~
 
-\section tutorial-quick-start Quick Start
+--------------------------------------------
+
+The documentation of *Meta* is currently scarce. The best resources are the
+<a href="group__meta.html">Reference</a> and the
+<a href="examples.html">Examples</a>.
+
+As a motivation and introduction to the library you can read
+[Eric's original blog post](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/),
+but please keep in mind that the library has evolved quite a bit since then.
 
 --------------------------------------------
 
-For a quick start see Eric Niebler's blog post:
-[A tiny metaprogramming library]([this blog post](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/)).
+## Tutorial
+
+The tutorial begins with a brief introduction to metafunctions, metafunction
+classes, and type lists. Then it moves to metafunction composition and
+currying. Finally, it covers type list algorithms and algorithms for working on
+integer sequences.
+
+### Metafunction
+
+Metafunctions are functions that operate on types. For example,
+
+\snippet example/tutorial_snippets.cpp meta_function0
+
+is a metafunction taking an arbitrary number of types that always returns
+void. The return value of a meta function is obtained from a nested type alias
+called (by convention) `type`. All of the metafunctions in the C++11 standard
+library follow this convention. C++11 template aliases allow us to write:
+
+\snippet example/tutorial_snippets.cpp meta_function1
+
+and thus to omit the `typename X::type` when calling a metafunction. C++14
+standard library provides `_t` metafunction aliases for all the metafunctions in
+the standard library.
+
+*Meta* provides `meta::eval<T>`, which evaluates the metafunction `T` by
+ returning the tested `T::type` alias. This allows metafunction aliases to be
+ written as follows:
+
+\snippet example/tutorial_snippets.cpp meta_function2
+
+### Metafunction Class
+
+A Metafunction Class is a form of metafunction suitable for higher-order
+metaprogramming. It is a class with a nested metafunction called (by convention)
+`apply`:
+
+\snippet example/tutorial_snippets.cpp meta_function_class0
+
+*Meta* provides the `meta::apply<F, Args...>` metafunction that evaluates the
+ metafunction class `F` with the arguments `Args`:
+
+\snippet example/tutorial_snippets.cpp meta_function_class1
+
+To turn a metafunction into a metafunction class *Meta* provides the
+`meta::quote<F>` metafunction:
+
+\snippet example/tutorial_snippets.cpp meta_function_class2
+
+Note that in the first case we create a metafunction class that will evaluate
+the metafunction through apply, while in the second case we create a
+metafunction class containing the already evaluated result.
+
+### Type lists
+
+A list of types `Ts...` can be stored in the metafunction
+`meta::list<Ts...>`. It provides a O(1) member function
+`meta::list::size()` that returns the size of the list.
+
+You can concatenate multiple lists using `meta::concat<Lists...>`:
+
+\snippet example/tutorial_snippets.cpp type_list0
+
+To flatten a list of lists, `meta::join<ListOfLists>` is provided:
+
+\snippet example/tutorial_snippets.cpp type_list1
+
+To convert other type sequences into a `meta::List`, the utility metafunction
+`meta::as_list<Sequence>` is provided. For example:
+
+\snippet example/tutorial_snippets.cpp type_list2
+
+> TODO: specify how to extend as_list to work on custom type sequences
+
+### Composition
+
+Multiple metafunctions classes can be composed into a single metafunction using
+`meta::compose<F0, F1, ..., FN>`, which returns a new metafunction class that
+performs `FN(... (F1(F0(Args...)) )`:
+
+\snippet example/tutorial_snippets.cpp composition0
+
+### Currying

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -6,36 +6,33 @@
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="modules" visible="yes"
                         title="Reference"
-                        intro="
-The reference documentation is split into logical modules, as documented in
-the user manual."/>
+                        intro="The reference documentation."/>
+    <tab type="examples" visible="yes" title="" intro=""/>
 
-    <tab type="usergroup" visible="yes" title="Indexes">
-      <tab type="classmembers" visible="yes"
+    <!-- We don't use what's below -->
+    <tab type="usergroup" visible="no" title="Indexes">
+      <tab type="classmembers" visible="no"
                                title="Methods"
                                intro="
 This is an index of all the methods with links to the
 corresponding documentation."/>
 
-      <tab type="classlist" visible="yes"
+      <tab type="classlist" visible="no"
                             title="Classes"
                             intro="
 This is an index of all the classes in the library with links to the
 corresponding documentation."/>
 
-      <tab type="filelist" visible="yes"
+      <tab type="filelist" visible="no"
                            title="Files"
                            intro=""/>
 
     </tab>
 
-    <!-- We don't use what's below -->
     <tab type="namespaces" visible="no" title="">
       <tab type="namespacelist" visible="no" title="" intro=""/>
       <tab type="namespacemembers" visible="no" title="" intro=""/>
     </tab>
-
-    <tab type="examples" visible="no" title="" intro=""/>
 
     <tab type="classes" visible="no" title="">
       <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(tutorial_snippets tutorial_snippets.cpp)
+add_test(example.tutorial_snippets, tutorial_snippets)
+
+add_executable(tuple_cat tuple_cat.cpp)
+add_test(example.tuple_cat, tuple_cat)

--- a/example/examples.hpp
+++ b/example/examples.hpp
@@ -1,0 +1,3 @@
+/// \file examples.hpp List of all examples
+
+/// \example tuple_cat.cpp Tuple concatenation example:

--- a/example/tuple_cat.cpp
+++ b/example/tuple_cat.cpp
@@ -1,0 +1,133 @@
+/// \file tuple_cat.cpp Example implementation of tuple cat using meta
+///
+/// Meta: a tiny metaprogramming library
+///
+///  Copyright Eric Niebler 2013-2015
+///
+///  Use, modification and distribution is subject to the
+///  Boost Software License, Version 1.0. (See accompanying
+///  file LICENSE_1_0.txt or copy at
+///  http://www.boost.org/LICENSE_1_0.txt)
+///
+/// Project home: https://github.com/ericniebler/meta
+///
+/// Acknowledgements: Thanks Stephan T. Lavavej for spreading the word about
+///                   tuple_cat, and the idea of bundling the tuples into a
+///                   tuple
+///                   of tuples and then using 2-dimensional indexing.
+#include <tuple>
+#include <meta/meta.hpp>
+
+using namespace meta;
+
+template <class T> struct dump;
+
+// Tuple cat is a function that takes N tuples and glues them together into one.
+//
+// The main idea behind the implementation is to take all the tuples and build
+// them up into a tuple of tuples. Since tuples are random-access, we can index
+// into this 2-dimensional array of tuples with (i,j) coordinates, where i is
+// the tuple index, and j the index of an element within the tuple i.
+
+// This helper function takes a tuple of tuples (Tuples), a list of tuple
+// indicies (Is), a list of tuple element indices (Js), and the type of the
+// tuple to be returned.
+template <typename Ret, typename... Is, typename... Js, typename Tuples>
+Ret tuple_cat_helper(list<Is...>, list<Js...>, Tuples tpls)
+{
+    // Note that for each element in a tuple we have a coordinate pair (i, j),
+    // that is, the length of the lists containing the Is and the Js must be
+    // equal:
+    static_assert(sizeof...(Is) == sizeof...(Js), "");
+    // It then explodes the tuple of tuples into the return type using the
+    // coordinates (i, j) for each element:
+    return Ret{std::get<Js::value>(std::get<Is::value>(tpls))...};
+}
+
+// Now we can implement tuple cat as follows:
+// - first we compute the inner indices (the i's), that is, to which tuple each
+//   element belongs,
+// - then we compute the outer indices (the j's), that is, the position of each
+//   element within their respective tuple
+template <
+  typename... Tuples,
+  // The return type of the tuple is computed by: creating a list for the
+  // elements of each tuple: list<...>, list<...>, ... Concatenating the lists
+  // into a single list, and returning a tuple of the list elements.
+  typename Res = apply_list<quote<std::tuple>, concat<as_list<Tuples>...>>>
+Res tuple_cat(Tuples &&... tpls)
+{
+    // With sizeof we compute the # of tuples to concatenate:
+    static constexpr std::size_t N = sizeof...(Tuples);
+
+    // To compute the inner indices:
+    //
+    // - First, we make a list containing one list
+    // with the elements of each tuple:
+    using list_of_lists_of_tuple_elements = list<as_list<Tuples>...>;
+    //   that is, for 3 tuples:
+    //     - tuple0<int, float>,
+    //     - tuple1<char>, and
+    //     - tuple2<float, unsigned>,
+    //   we have: list<list<int, float>, list<char>, list<float, unsigned>.
+    //
+    // - Then, we create for each tuple, a metafunction that, when called with
+    // any type, returns the tuple index. That is, we make an index sequence
+    // from [0, N), e.g., [0, 1, 2], and transform it with the metafunction
+    // always, such that we get a list of metafunctions:
+    // [always0, always1, always2].
+    using always_tuple_index =
+      transform<as_list<make_index_sequence<N>>, quote<always>>;
+    //
+    // - Afterwards, we transform(list_of_tuples, always_tuple_indices,
+    // transform):
+    //   That is, for each list of tuple elements, e.g., list<int, float>,
+    //   we call transform again with a metafunction, that no matter what type
+    //   is passed, returns the tuple index:
+    //   transform(list<int, float>, always0)
+    //       -> list<always0(int), always0(float)>
+    //       -> list<0, 0>
+    //   For the next tuples we get a list<1>, and list<2, 2>.
+    //   This returns a list of lists of inner indices:
+    using list_of_list_of_inner_indices =
+      transform<list_of_lists_of_tuple_elements, always_tuple_index,
+                quote<transform>>;
+    //   That is, listlist<0, 0>, list<1>, list<2,2>>
+    //
+    // - Finally: we flatten the list, and get the list of inner indices:
+    using inner = join<list_of_list_of_inner_indices>; // e.g. [0, 0, 1, 2, 2]
+
+    // To compute the outer indices:
+    //
+    // - Create a list of lists of tuple elements as above
+    //
+    // - For each lists, replace the list with a list of [0, size(list)) for
+    //   each list. This is done by calling transform on the list of lists of
+    //   tuple elements, with a metafunction that gets the list size, makes an
+    //   index sequence, and returns that as a list:
+    //     f(list) = as_list(make_index_sequence(size(list)));
+    //   This produces list<list<0, 1>, list<0>, list<0, 1>>:
+    // - Finally, we flatten the result: list<0, 1, 0, 0, 1>.
+    using outer = join< // flatten:
+      // replace list of list of tuple elements, with list of indices for each
+      // tuple:
+      transform<
+        list<as_list<Tuples>...>,
+        // f(list) = as_list(make_index_sequence(size(list)));
+        compose<quote<as_list>, quote_i<std::size_t, make_index_sequence>,
+                quote<size>>>>;
+    return tuple_cat_helper<Res>(
+      inner{}, outer{}, std::forward_as_tuple(std::forward<Tuples>(tpls)...));
+}
+
+int main()
+{
+    std::tuple<int, short, long> t1;
+    std::tuple<> t2;
+    std::tuple<float, double, long double> t3;
+    std::tuple<void *, char *> t4;
+    auto x = ::tuple_cat(t1, t2, t3, t4);
+    using expected_type =
+      std::tuple<int, short, long, float, double, long double, void *, char *>;
+    static_assert(std::is_same<decltype(x), expected_type>::value, "");
+}

--- a/example/tutorial_snippets.cpp
+++ b/example/tutorial_snippets.cpp
@@ -1,0 +1,136 @@
+/// \file metafunction.cpp Code snippets for the tutorial
+///
+/// Meta: a tiny metaprogramming library
+///
+///  Copyright Eric Niebler 2013-2015
+///
+///  Use, modification and distribution is subject to the
+///  Boost Software License, Version 1.0. (See accompanying
+///  file LICENSE_1_0.txt or copy at
+///  http://www.boost.org/LICENSE_1_0.txt)
+///
+/// Project home: https://github.com/ericniebler/meta
+///
+#include <tuple>
+#include <type_traits>
+#include <meta/meta.hpp>
+
+template <class T> struct dump;
+
+namespace metafunction0
+{
+    /// [meta_function0]
+    template <typename... Args> struct mf
+    {
+        using type = void;
+    };
+    using result = typename mf<int, double>::type;
+    static_assert(std::is_same<result, void>{}, "");
+    /// [meta_function0]
+}
+
+using metafunction0::mf;
+
+namespace metafunction1
+{
+    /// [meta_function1]
+    template <typename... Args> using mf_t = typename mf<Args...>::type;
+    using result = mf_t<int, double>;
+    static_assert(std::is_same<result, void>{}, "");
+    /// [meta_function1]
+}
+
+using metafunction1::mf_t;
+
+namespace metafunction2
+{
+    /// [meta_function2]
+    template <typename... Args> using mf2_t = meta::eval<mf<Args...>>;
+    using result = mf2_t<int, double>;
+    static_assert(std::is_same<result, void>{}, "");
+    /// [meta_function2]
+}
+
+namespace metafunction_class0
+{
+    /// [meta_function_class0]
+    struct mfc
+    {
+        template <typename... Args> using apply = void;
+    };
+    /// [meta_function_class0]
+
+    /// [meta_function_class1]
+    using result = mfc::apply<int, double>;
+    static_assert(std::is_same<result, void>{}, "");
+    /// [meta_function_class1]
+}
+
+namespace metafunction_class1
+{
+    /// [meta_function_class2]
+    using mf_class0 = meta::quote<mf>;
+    using result0 = meta::apply<mf_class0, int, double>;
+    static_assert(std::is_same<result0, mf<int, double>>{}, "");
+    static_assert(std::is_same<meta::eval<result0>, void>{}, "");
+
+    using mf_class1 = meta::quote<mf_t>;
+    using result1 = meta::apply<mf_class1, int, double>;
+    static_assert(std::is_same<result1, void>{}, "");
+    /// [meta_function_class2]
+}
+
+namespace type_list0
+{
+    /// [type_list0]
+    using list0 = meta::list<int, double>;
+    using list1 = meta::list<>;
+    using list2 = meta::list<float>;
+    using result = meta::concat<list0, list1, list2>;
+    static_assert(std::is_same<result, meta::list<int, double, float>>{}, "");
+    /// [type_list0]
+}
+
+namespace type_list1
+{
+    /// [type_list1]
+    using list0 = meta::list<int, double>;
+    using list1 = meta::list<>;
+    using list2 = meta::list<float>;
+    using list_of_lists = meta::list<list0, list1, list2>;
+    using result = meta::join<list_of_lists>;
+    static_assert(std::is_same<result, meta::list<int, double, float>>{}, "");
+    /// [type_list1]
+}
+
+namespace type_list2
+{
+    /// [type_list2]
+    using t = std::tuple<int, double, float>;
+    using l = meta::as_list<t>;
+    static_assert(std::is_same<l, meta::list<int, double, float>>{}, "");
+
+    using i = meta::make_index_sequence<3>;
+    using il = meta::as_list<i>;
+    static_assert(
+      std::is_same<il, meta::list<std::integral_constant<std::size_t, 0>,
+                                  std::integral_constant<std::size_t, 1>,
+                                  std::integral_constant<std::size_t, 2>>>{},
+      "");
+    /// [type_list2]
+}
+
+namespace composition0
+{
+    /// [composition0]
+    template <class T> using mf0 = meta::eval<std::make_signed<T>>;
+    template <class T> using mf1 = meta::eval<std::add_const<T>>;
+    template <class T> using mf2 = meta::eval<std::add_lvalue_reference<T>>;
+
+    using mf =
+      meta::compose<meta::quote<mf2>, meta::quote<mf1>, meta::quote<mf0>>;
+    static_assert(std::is_same<meta::apply<mf, unsigned>, int const &>{}, "");
+    /// [composition0]
+}
+
+int main() { return 0; }

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1,4 +1,5 @@
-/// \file meta.hpp Tiny meta-programming library
+/// \file meta.hpp Tiny meta-programming library.
+//
 // Meta library
 //
 //  Copyright Eric Niebler 2014-2015
@@ -8,8 +9,9 @@
 //  file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
-// Project home: https://github.com/ericniebler/range-v3
+// Project home: https://github.com/ericniebler/meta
 //
+
 
 #ifndef META_HPP
 #define META_HPP
@@ -872,8 +874,8 @@ namespace meta
     /// construct a new list by calling \c Fun with the elements from the lists
     /// pairwise.
     /// \par Complexity
-    /// \f$ O(N*M) \f$, where \f$ N \f$ is the size of the outer list, and \f$ M
-    /// \f$ is the size of the inner lists.
+    /// \f$ O(N*M) \f$, where \f$ N \f$ is the size of the outer list, and
+    /// \f$ M \f$ is the size of the inner lists.
     template <typename Fun, typename ListOfLists>
     using zip_with =
       transform<foldl<ListOfLists, repeat_n<size<front<ListOfLists>>, Fun>,
@@ -885,8 +887,8 @@ namespace meta
     /// Given a list of lists of types, construct a new list by grouping the
     /// elements from the lists pairwise into `meta::list`s.
     /// \par Complexity
-    /// \f$ O(N*M) \f$, where \f$ N \f$ is the size of the outer list, and \f$ M
-    /// \f$ is the size of the inner lists.
+    /// \f$ O(N*M) \f$, where \f$ N \f$ is the size of the outer list, and
+    /// \f$ M \f$ is the size of the inner lists.
     template <typename ListOfLists>
     using zip = zip_with<quote<list>, ListOfLists>;
 

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,15 @@
 # Meta: A tiny metaprogramming library
 
-*Meta: a tiny metaprogramming library* is the evolution of a minimal useful set
-of primitives for manipulating lists of types introduced by Eric Niebler in
-[this blog post](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/)
-and used throught his
-[range-v3 library](https://github.com/ericniebler/range-v3).
+[![Build Status](https://travis-ci.org/ericniebler/meta.svg?branch=master)](https://travis-ci.org/ericniebler/meta)
 
-All of the source code in this project was written by
-[Eric Niebler](https://github.com/ericniebler) as a set of utilities within his
-[range-v3 library](https://github.com/ericniebler/range-v3) and is under the
-Boost Software License (see the attached LICENSE.md) file.
+_Meta_ is a C++14 tiny header-only metaprogramming library released under the
+Boost Software License. To compile with meta you just have to:
 
-[Gonzalo Brito Gadeschi](https://github.com/gnzlbg) made some minor tweaks to the comments, examples, test, and
-documentation.
+```.cpp
+#include <meta/meta.hpp>
+```
+
+
 
 For a quick start see Eric Niebler's blog post:
-[A tiny metaprogramming library]([this blog post](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/)). (Note: the names in Meta are different from those describe in the blog post, but the overall design remains the same.)
-
-This library is header-only; to compile with meta, you just have to: `#include <meta/meta.hpp>`.
+[A tiny metaprogramming library](http://ericniebler.com/2014/11/13/tiny-metaprogramming-library/). (Note: the names in Meta are different from those describe in the blog post, but the overall design remains the same.)


### PR DESCRIPTION
- moved the tuple_cat example into the example directory
- commented the tuple_cat example
- added examples to the doxygen documentation
- added small tutorial sections for metafunctions, metafunction classes,
  type lists, and metafunction composition.
- enabled travis (updated also CMakeLists.txt with -std=c++11)