### PR TITLE
for_each

### DIFF
--- a/example/tuple_cat.cpp
+++ b/example/tuple_cat.cpp
@@ -13,9 +13,12 @@
 ///
 /// Acknowledgements: Thanks Stephan T. Lavavej for spreading the word about
 ///                   tuple_cat, and the idea of bundling the tuples into a
-///                   tuple
-///                   of tuples and then using 2-dimensional indexing.
+///                   tuple of tuples and then using 2-dimensional indexing.
+///                   He also discovered a bug in the implementation when
+///                   using tuple_cat to concatenate temporary tuples
+///                   including move-only types.
 #include <tuple>
+#include <memory>
 #include <meta/meta.hpp>
 
 using namespace meta;
@@ -31,7 +34,7 @@ using namespace meta;
 // indices (Is), a list of tuple element indices (Js), and the type of the
 // tuple to be returned.
 template <typename Ret, typename... Is, typename... Js, typename Tuples>
-Ret tuple_cat_helper(list<Is...>, list<Js...>, Tuples tpls)
+Ret tuple_cat_helper(list<Is...>, list<Js...>, Tuples &&tpls)
 {
     // Note that for each element in a tuple we have a coordinate pair (i, j),
     // that is, the length of the lists containing the Is and the Js must be
@@ -39,7 +42,8 @@ Ret tuple_cat_helper(list<Is...>, list<Js...>, Tuples tpls)
     static_assert(sizeof...(Is) == sizeof...(Js), "");
     // It then explodes the tuple of tuples into the return type using the
     // coordinates (i, j) for each element:
-    return Ret{std::get<Js::value>(std::get<Is::value>(tpls))...};
+    return Ret{
+      std::get<Js::value>(std::get<Is::value>(std::forward<Tuples>(tpls)))...};
 }
 
 // Now we can implement tuple cat as follows:
@@ -124,8 +128,9 @@ int main()
     std::tuple<> t2;
     std::tuple<float, double, long double> t3;
     std::tuple<void *, char *> t4;
-    auto x = ::tuple_cat(t1, t2, t3, t4);
+    auto x = ::tuple_cat(t1, t2, t3, t4, std::make_tuple(std::unique_ptr<int>{}));
     using expected_type =
-      std::tuple<int, short, long, float, double, long double, void *, char *>;
+      std::tuple<int, short, long, float, double, long double, void *, char *,
+                 std::unique_ptr<int>>;
     static_assert(std::is_same<decltype(x), expected_type>::value, "");
 }

--- a/example/tuple_cat.cpp
+++ b/example/tuple_cat.cpp
@@ -28,7 +28,7 @@ using namespace meta;
 // the tuple index, and j the index of an element within the tuple i.
 
 // This helper function takes a tuple of tuples (Tuples), a list of tuple
-// indicies (Is), a list of tuple element indices (Js), and the type of the
+// indices (Is), a list of tuple element indices (Js), and the type of the
 // tuple to be returned.
 template <typename Ret, typename... Is, typename... Js, typename Tuples>
 Ret tuple_cat_helper(list<Is...>, list<Js...>, Tuples tpls)

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -115,6 +115,12 @@ namespace meta
     /// \f$ O(1) \f$.
     template <class T> using sizeof_ = meta::size_t<sizeof(T)>;
 
+    /// A metafunction that computes the alignment required for
+    /// any instance of the type \p T.
+    /// \par Complexity
+    /// \f$ O(1) \f$.
+    template <class T> using alignof_ = meta::size_t<alignof(T)>;
+
     /// An integral constant wrapper for \c bool.
     template <bool B> using bool_ = std::integral_constant<bool, B>;
 

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -961,6 +961,53 @@ namespace meta
     template <typename List, typename Predicate>
     using filter = meta::foldl<List, meta::list<>, detail::filter_<Predicate>>;
 
+    ////////////////////////////////////////////////////////////////////////////
+    // for_each
+    /// \cond
+    namespace detail
+    {
+        struct for_each_fn
+        {
+           private:
+            template <class UnaryFunction>
+            constexpr auto impl_(UnaryFunction &&unary_function) const
+            {
+                return std::forward<UnaryFunction>(unary_function);
+            }
+
+            template <class UnaryFunction, class Arg>
+            constexpr auto impl_(UnaryFunction &&unary_function,
+                                 Arg &&arg) const
+            {
+                unary_function(std::forward<Arg>(arg));
+                return impl_(std::forward<UnaryFunction>(unary_function));
+            }
+
+            template <class UnaryFunction, class Arg, class... Args>
+            constexpr auto impl_(UnaryFunction &&unary_function, Arg &&arg,
+                                 Args &&... args) const
+            {
+                unary_function(std::forward<Arg>(arg));
+                return impl_(std::forward<UnaryFunction>(unary_function),
+                             std::forward<Args>(args)...);
+            }
+
+           public:
+            template <class UnaryFunction, class... Args>
+            constexpr auto operator()(meta::list<Args...>,
+                                      UnaryFunction &&unary_function) const
+            {
+                return impl_(std::forward<UnaryFunction>(unary_function),
+                             Args{}...);
+            }
+        };
+    } // namespace detail
+    /// \endcond
+
+    /// for_each(List, UnaryFunction) calls the \p UnaryFunction for each
+    /// argument in the \p List.
+    static constexpr detail::for_each_fn for_each{};
+
     ////////////////////////////////////////////////////////////////////////
     // zip_with
     /// Given a list of lists of types \p ListOfLists and a Metafunction

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -107,6 +107,14 @@ static_assert(can_apply<meta::quote<std::pair>, int, int>::value, "");
 static_assert(!can_apply<meta::quote<std::pair>, int, int, int>::value, "");
 #endif
 
+struct check_integral
+{
+    template <class T> void operator()(T &&)
+    {
+        static_assert(std::is_integral<T>{}, "");
+    }
+};
+
 int main()
 {
     // meta::sizeof_
@@ -135,6 +143,12 @@ int main()
           std::is_same<fl,
                        meta::filter<l, meta::quote<std::is_floating_point>>>{},
           "");
+    }
+
+    // meta::for_each
+    {
+        using l = meta::list<int, long, short>;
+        meta::for_each(l{}, check_integral());
     }
 
     test_tuple_cat();


### PR DESCRIPTION
Implements `meta::for_each(List, UnaryFunction)` and `meta::alignof_`.

I think `meta::for_each` is a very useful run-time utility to have, still within the scope of meta.

It also fixes a typo in the `tuple_cat` example.