### PR TITLE
at, find_index, reverse_find_index

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -136,35 +136,28 @@ You can add and remove elements from a list by using the transformation algorith
 
 \snippet example/tutorial_snippets.cpp type_list2
 
-You can concatenate multiple lists using `meta::concat<Lists...>`:
+You can concatenate, flatten, and zip multiple lists using
+`meta::concat<Lists...>`, `meta::join<ListOfLists>`, and  `meta::zip<ListOfLists>`:
 
 \snippet example/tutorial_snippets.cpp type_list3
-
-To flatten a list of lists, `meta::join<ListOfLists>` is provided:
-
-\snippet example/tutorial_snippets.cpp type_list4
-
-To zip a list of lists, `meta::zip<ListOfLists>` is provided:
-
-\snippet example/tutorial_snippets.cpp type_list5
 
 > TODO:  `meta::zip_with` examples
 
 Other typical operations on type lists include iteration, reductions, finding
 elements, removing duplicates:
 
-\snippet example/tutorial_snippets.cpp type_list6
+\snippet example/tutorial_snippets.cpp type_list4
 
 To convert other type sequences into a `meta::list`, the utility metafunction
 `meta::as_list<Sequence>` is provided. For example:
 
-\snippet example/tutorial_snippets.cpp type_list7
+\snippet example/tutorial_snippets.cpp type_list5
 
 To use meta with your own data types you can specialize the
 `meta::extension:apply_list` metafunction for your own data type. For example,
 to use meta with C++14 `std::integer_sequence`, you can:
 
-\snippet example/tutorial_snippets.cpp type_list8
+\snippet example/tutorial_snippets.cpp type_list6
 
 ### Overview
 

--- a/example/tutorial_snippets.cpp
+++ b/example/tutorial_snippets.cpp
@@ -134,9 +134,15 @@ namespace type_list0
     using back = meta::back<list>;
     static_assert(std::is_same<back, float>{}, "");
 
-    using at_1 = meta::list_element_c<1, list>;
+    using at_1 = meta::at_c<1, list>;
 
     static_assert(std::is_same<at_1, double>{}, "");
+
+    using index_double = meta::find_index<double, list>;
+    static_assert(index_double{} == 1, "");
+
+    using index_char = meta::find_index<char, list>;
+    static_assert(index_char{} == meta::npos(), "");
 
     static_assert(!meta::empty<list>{}, "");
     /// [type_list0]
@@ -147,7 +153,7 @@ namespace type_list1
     using list = type_list0::list;
     /// [type_list1]
     using i = meta::size_t<1>;
-    using at_1 = meta::list_element<i, list>;
+    using at_1 = meta::at<i, list>;
     static_assert(std::is_same<at_1, double>{}, "");
     /// [type_list1]
 }
@@ -175,41 +181,27 @@ namespace type_list3
     /// [type_list3]
     using list0 = meta::list<int, double>;
     using list1 = meta::list<>;
-    using list2 = meta::list<float>;
-    using result = meta::concat<list0, list1, list2>;
-    static_assert(std::is_same<result, meta::list<int, double, float>>{}, "");
+    using list2 = meta::list<float, char>;
+
+    using concatenated = meta::concat<list0, list1, list2>;
+    static_assert(std::is_same<concatenated, meta::list<int, double, float, char>>{}, "");
+
+    using list_of_lists = meta::list<list0, list1, list2>;
+    using flattened = meta::join<list_of_lists>;
+    static_assert(std::is_same<flattened, meta::list<int, double, float, char>>{}, "");
+
+    using list_of_lists_of_same_length = meta::list<list0, list2>;
+    using zipped = meta::zip<list_of_lists_of_same_length>;
+    static_assert(
+        std::is_same<zipped, meta::list<meta::list<int, float>, meta::list<double, char>>>{}, "");
     /// [type_list3]
 }
 
 namespace type_list4
 {
-    /// [type_list4]
-    using list0 = meta::list<int, double>;
-    using list1 = meta::list<>;
-    using list2 = meta::list<float>;
-    using list_of_lists = meta::list<list0, list1, list2>;
-    using result = meta::join<list_of_lists>;
-    static_assert(std::is_same<result, meta::list<int, double, float>>{}, "");
-    /// [type_list4]
-}
-
-namespace type_list5
-{
-    /// [type_list5]
-    using list0 = meta::list<int, short, unsigned>;
-    using list1 = meta::list<float, double, char>;
-    using result = meta::zip<meta::list<list0, list1>>;
-    static_assert(std::is_same<result, meta::list<meta::list<int, float>, meta::list<short, double>,
-                                                  meta::list<unsigned, char>>>{},
-                  "");
-    /// [type_list5]
-} // namespace type_list5
-
-namespace type_list6
-{
     using namespace meta::placeholders;
 
-    /// [type_list6]
+    /// [type_list4]
     using namespace meta::lazy;
     using l = meta::list<short, int, long, long long, float, float>;
 
@@ -228,12 +220,12 @@ namespace type_list6
 
     using unique_types = meta::unique<l>;
     static_assert(std::is_same<unique_types, meta::list<short, int, long, long long, float>>{}, "");
-    /// [type_list6]
-} // namespace type_list6
+    /// [type_list4]
+} // namespace type_list4
 
-namespace type_list7
+namespace type_list5
 {
-    /// [type_list7]
+    /// [type_list5]
     using t = std::tuple<int, double, float>;
     using l = meta::as_list<t>;
     static_assert(std::is_same<l, meta::list<int, double, float>>{}, "");
@@ -244,11 +236,11 @@ namespace type_list7
                                               std::integral_constant<std::size_t, 1>,
                                               std::integral_constant<std::size_t, 2>>>{},
                   "");
-    /// [type_list7]
+    /// [type_list5]
 }
 
 #if __cplusplus >= 201402L
-/// [type_list8]
+/// [type_list6]
 namespace meta
 {
     namespace extension
@@ -260,7 +252,7 @@ namespace meta
         };
     } // namespace extension
 } // namespace meta
-/// [type_list8]
+/// [type_list6]
 #endif
 
 namespace composition0

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -140,7 +140,8 @@ struct check_integral
         static_assert(std::is_integral<T>{}, "");
     }
 };
-
+template <class T>
+struct dump;
 int main()
 {
     // meta::sizeof_
@@ -172,17 +173,41 @@ int main()
         meta::for_each(l{}, check_integral());
     }
 
-    // meta::index
+    // meta::find_index
     {
-        using l = meta::list<int, long, short>;
-        static_assert(meta::index<int, l>{} == 0, "");
-        static_assert(meta::index<long, l>{} == 1, "");
-        static_assert(meta::index<short, l>{} == 2, "");
-        static_assert(meta::index<double, l>{} == l::size(), "");
-        static_assert(meta::index<float, l>{} == l::size(), "");
+        using l = meta::list<int, long, short, int>;
+        static_assert(meta::find_index<int, l>{} == 0, "");
+        static_assert(meta::find_index<long, l>{} == 1, "");
+        static_assert(meta::find_index<short, l>{} == 2, "");
+        static_assert(meta::find_index<double, l>{} == meta::npos{}, "");
+        static_assert(meta::find_index<float, l>{} == meta::npos{}, "");
 
         using l2 = meta::list<>;
-        static_assert(meta::index<double, l2>{} == l2::size(), "");
+        static_assert(meta::find_index<double, l2>{} == meta::npos{}, "");
+
+        using namespace meta::placeholders;
+
+        using lambda = meta::lambda<_a, _b, meta::lazy::find_index<_a, _b>>;
+        using result = meta::apply<lambda, long, l>;
+        static_assert(result{} == 1, "");
+    }
+
+    // meta::reverse_find_index
+    {
+        using l = meta::list<int, long, short, int>;
+
+        static_assert(meta::reverse_find_index<int, l>{} == 3, "");
+        static_assert(meta::reverse_find_index<long, l>{} == 1, "");
+        static_assert(meta::reverse_find_index<short, l>{} == 2, "");
+        static_assert(meta::reverse_find_index<double, l>{} == meta::npos{}, "");
+        static_assert(meta::reverse_find_index<float, l>{} == meta::npos{}, "");
+
+        using l2 = meta::list<>;
+        static_assert(meta::reverse_find_index<double, l2>{} == meta::npos{}, "");
+
+        using lambda = meta::lambda<_a, _b, meta::lazy::reverse_find_index<_a, _b>>;
+        using result = meta::apply<lambda, long, l>;
+        static_assert(result{} == 1, "");
     }
 
     test_tuple_cat();


### PR DESCRIPTION
-  Rename: `meta::list_element` to `meta::at`, and  `meta::lis_element_c` to `meta::at_c` (in the spirit of Boost.MPL and Boost.Fusion, closes #11 ).
-  Rename: `meta::index` to `meta::find_index`, since it is `O(N)`, somehow the name index makes it feels like it is `O(1)`, I moved this from list utilities to query algorithms.
- Add: `meta::reverse_find_index`.
- Add: `meta::npos` and `meta::list::npos()`.
- Change: semantics of `meta::find_index` (old `meta::index`) to return `meta::npos` if item not found. The same applies for `meta::reverse_find_index`. 
- Simplifies list `concat`, `join`, and `zip` examples into one.
- Add: examples for `meta::find_index` and `meta::list::npos()`/`meta::npos`.
