### PR TITLE
Alternate formulation of and_c that allows gcc5.1 to compile range-v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@ matrix:
       addons: &clang37
         apt:
           packages:
+            - util-linux
             - clang-3.7
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise
+            - llvm-toolchain-precise-3.7
 
     # Test clang-3.7:  C++14
     - env: CLANG_VERSION=3.7 CPP=14 LIBCXX=On

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -895,9 +895,17 @@ namespace meta
 
         /// Logically and together all the Boolean parameters
         /// \ingroup logical
+#if (__GNUC__ == 5) && (__GNUC_MINOR__ == 1) && !defined(__clang__)
+        // Alternative formulation of and_c to workaround
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66405
+        template <bool... Bools>
+        using and_c = std::is_same<integer_sequence<bool, true, Bools...>,
+                                   integer_sequence<bool, Bools..., true>>;
+#else
         template <bool... Bools>
         using and_c = std::is_same<integer_sequence<bool, Bools...>,
                                    integer_sequence<bool, (Bools || true)...>>;
+#endif
 
         /// Logically and together all the integral constant-wrapped Boolean parameters, \e without
         /// doing short-circuiting.


### PR DESCRIPTION
Also fix clang-3.7 Travis builds using ericniebler/range-v3@d0ba804f