### PR TITLE
Readme

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -34,7 +34,7 @@ terminology and esoteric concepts.
 
 ## Tutorial
 
-The tutorial begins with a brief introduction to *traits*, *aliases*, and *Callables*.
+The tutorial begins with a brief introduction to *trait*s, *alias*es, and *Callable*s.
 Then it moves to *trait* composition and currying. Finally, it covers type list algorithms
 and algorithms for working on integer sequences.
 
@@ -48,7 +48,7 @@ For example,
 \snippet example/tutorial_snippets.cpp trait0
 
 is a *trait* taking an arbitrary number of types that always "returns" `void`. There are
-many familiar examples of *traits* in the Standard Library; `std::remove_reference` and
+many familiar examples of *trait*s in the Standard Library; `std::remove_reference` and
 `std::is_void` to name two.
 
 ## Aliases
@@ -60,7 +60,7 @@ out interface differences. Below is an example of an *alias template*:
 \snippet example/tutorial_snippets.cpp trait1
 
 Notice how `t_t<int, double>` becomes a synonym for `void`. The C++14 standard library
-provides `_t` *alias templates* for all the *traits* in the standard library.
+provides `_t` *alias templates* for all the *trait*s in the standard library.
 
 *Meta* provides `meta::_t<T>`, which evaluates the *trait* `T` by aliasing the nested
 `T::type` *alias*. This allows us to alias the nested `type` of a *trait* as follows:
@@ -68,7 +68,7 @@ provides `_t` *alias templates* for all the *traits* in the standard library.
 \snippet example/tutorial_snippets.cpp trait2
 
 \note *Alias templates* have primacy in Meta. This is different from other metaprogramming
-libraries you may be familiar with, which make *traits* (aka metafunctions) the prime
+libraries you may be familiar with, which make *trait*s (aka metafunctions) the prime
 abstraction. The rest of this guide uses the term "alias" to mean "alias template".
 
 ### Callables
@@ -78,7 +78,7 @@ A *Callable* is a class (it is not a template!) suitable for higher-order metapr
 \snippet example/tutorial_snippets.cpp callable0
 
 All of the algorithms that take "functions" as arguments expect *Callable*s instead of
-raw *aliases*.  *Meta* provides the `meta::invoke<F, Args...>` *alias* that evaluates the
+raw *alias*es.  *Meta* provides the `meta::invoke<F, Args...>` *alias* that evaluates the
 *Callable* `F` with the arguments `Args`:
 
 \snippet example/tutorial_snippets.cpp callable1
@@ -130,14 +130,14 @@ context.
 
 ### Logical operations
 
-The *traits* `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
+The *trait*s `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
 the basic logical operations with types:
 
 \snippet example/tutorial_snippets.cpp logical_operations0
 
 ### Eager and lazy evaluation
 
-> TODO *aliases* are eager, `meta::defer`, `meta::lazy` namespace.
+> TODO *alias*es are eager, `meta::defer`, `meta::lazy` namespace.
 
 ### Lambdas
 
@@ -153,7 +153,7 @@ static member function `meta::list::size()` that returns the size of the list.
 \snippet example/tutorial_snippets.cpp type_list0
 
 As you can see, the `meta::front<List>`, `meta::back<List>`, and
-`meta::at_c<List, std::size_t>` *aliases* provide access to the elements of the list. The
+`meta::at_c<List, std::size_t>` *alias*es provide access to the elements of the list. The
 `meta::empty<List>` *alias* is `std::true_type` if the list is empty. The
 `meta::at<List, meta::size_t<N>>` *alias* differs from `meta::at_c` in that it takes a
 `meta::size_t<N>` (`std::integral_constant<std::size_t, N>`) instead of an integer:

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,66 +34,65 @@ terminology and esoteric concepts.
 
 ## Tutorial
 
-The tutorial begins with a brief introduction to traits, aliases, and callables.
-Then it moves to trait composition and currying. Finally, it covers type list algorithms
+The tutorial begins with a brief introduction to *traits*, *aliases*, and *Callables*.
+Then it moves to *trait* composition and currying. Finally, it covers type list algorithms
 and algorithms for working on integer sequences.
 
 TODO This feels backwards. Algorithms come first. Everything else is in support of them.
 
 ### Traits
 
-*Traits* are class templates that have a nested type alias called (by convention) `type`.
+*Traits* are class templates that have a nested type *alias* called (by convention) `type`.
 For example,
 
 \snippet example/tutorial_snippets.cpp trait0
 
-is a trait taking an arbitrary number of types that always "returns" `void`. There are
-many familiar examples of traits in the Standard Library; `std::remove_reference` and
+is a *trait* taking an arbitrary number of types that always "returns" `void`. There are
+many familiar examples of *traits* in the Standard Library; `std::remove_reference` and
 `std::is_void` to name two.
 
 ## Aliases
 
-An *alias* is a synonym for a type. C++11 introduced alias *templates*, which are names
-that refer to a family of types. Alias templates simplify template syntax and smooth
-out interface differences. Below is an example of an alias template:
+An *alias* is a synonym for a type. C++11 introduced *alias templates*, which are names
+that refer to a family of types. *Alias templates* simplify template syntax and smooth
+out interface differences. Below is an example of an *alias template*:
 
 \snippet example/tutorial_snippets.cpp trait1
 
 Notice how `t_t<int, double>` becomes a synonym for `void`. The C++14 standard library
-provides `_t` alias templates for all the traits in the standard library.
+provides `_t` *alias templates* for all the *traits* in the standard library.
 
-*Meta* provides `meta::_t<T>`, which evaluates the trait `T` by aliasing the nested
-`T::type` alias. This allows us to alias the nested `type` of a trait as follows:
+*Meta* provides `meta::_t<T>`, which evaluates the *trait* `T` by aliasing the nested
+`T::type` *alias*. This allows us to alias the nested `type` of a *trait* as follows:
 
 \snippet example/tutorial_snippets.cpp trait2
 
-\note Alias templates have primacy in Meta. This is different from other metaprogramming
-libraries you may be familiar with, which make traits (aka metafunctions) the prime
+\note *Alias templates* have primacy in Meta. This is different from other metaprogramming
+libraries you may be familiar with, which make *traits* (aka metafunctions) the prime
 abstraction. The rest of this guide uses the term "alias" to mean "alias template".
 
-### Callables
+### *Callable*s
 
-A *Callable* is a kind of alias suitable for higher-order metaprogramming. It is
-a class (not a template!) with a nested alias called (by convention) `invoke`:
+A **Callable** is a class (it is not a template!) suitable for higher-order metaprogramming. It containts a nested *alias* called (by convention) `invoke`:
 
 \snippet example/tutorial_snippets.cpp callable0
 
-All of the algorithms that take "functions" as arguments expect Callables instead of
-raw aliases.  *Meta* provides the `meta::invoke<F, Args...>` alias that evaluates the
-Callable `F` with the arguments `Args`:
+All of the algorithms that take "functions" as arguments expect *Callable*s instead of
+raw *aliases*.  *Meta* provides the `meta::invoke<F, Args...>` *alias* that evaluates the
+*Callable* `F` with the arguments `Args`:
 
 \snippet example/tutorial_snippets.cpp callable1
 
-To turn an ordinary alias into a Callable *Meta* provides the `meta::quote<F>` trait:
+To turn an ordinary *trait* into a *Callable* *Meta* provides the `meta::quote<F>` *Callable*:
 
 \snippet example/tutorial_snippets.cpp callable2
 
-Note that in the first case we create a Callable that evaluates to the trait itself,
-while in the second case we create a Callable that evaluates to the nested `type` of
-the trait.
+Note that in the first case we create a *Callable* that evaluates to the *trait* itself,
+while in the second case we create a *Callable* that evaluates to the nested `type` of
+the *trait*.
 
-When "quoting" a trait, it is often desirable for the resulting Callable to refer to
-the nested `type` instead of the trait itself. For that we can use `meta::quote_trait`.
+When "quoting" a *trait*, it is often desirable for the resulting *Callable* to refer to
+the nested `type` instead of the *trait* itself. For that we can use `meta::quote_trait`.
 Consider:
 
 \snippet example/tutorial_snippets.cpp callable3
@@ -101,63 +100,62 @@ Consider:
 Notice that `meta::quote<std::add_pointer_t>` and `meta::quote_trait<std::add_pointer>`
 mean the same thing.
 
-\note You may wonder what advantage Callables have over alias templates. A Callable is a
-*type* that represents a computation. Much of Meta revolves around types and the
-computation of types. Sometimes it's desirable to compute a computation, or to use a
+\note You may wonder what advantage *Callable*s have over *alias templates*. A *Callable* is a *type* that represents a computation (it is the metaprogramming 
+analogue to a functor class which has a call operator `operator()(...)`). Much of Meta revolves around types and the computation of types. Sometimes it's desirable to compute a computation, or to use a
 computation as an argument to another computation. In those cases, it's very handy for
 computations to themselves be types and not templates.
 
 ### Composition
 
-Multiple Callables can be composed into a single Callable using
-`meta::compose<F0, F1, ..., FN>`, which names a new Callable that performs
+Multiple *Callable*s can be composed into a single *Callable* using
+`meta::compose<F0, F1, ..., FN>`, which names a new *Callable* that performs
 `F0(F1(...(FN(Args...))))`:
 
 \snippet example/tutorial_snippets.cpp composition0
 
 ### Partial function application
 
-You can turn a Callable expecting *N* arguments into a Callable expecting *N-M*
+You can turn a *Callable* expecting *N* arguments into a *Callable* expecting *N-M*
 arguments by binding *M* arguments to the front or the back of its argument list. You can
-use `meta::bind_front` and `meta::bind_back` for that. Below we create a Callable
-that tests whether a type is `float` by reusing the `std::is_same` trait:
+use `meta::bind_front` and `meta::bind_back` for that. Below we create a *Callable*
+that tests whether a type is `float` by reusing the `std::is_same` *trait*:
 
 \snippet example/tutorial_snippets.cpp partial_application0
 
-\note If `std::is_same` is a trait, why did we use `meta::quote` instead of
-`meta::quote_trait`? In this case, it makes no difference. In addition to being a trait,
+\note If `std::is_same` is a *trait*, why did we use `meta::quote` instead of
+`meta::quote_trait`? In this case, it makes no difference. In addition to being a *trait*,
 `std::is_same<X, Y>` inherits from `std::integral_constant<bool, true-or-false>` so we
 can construct an instance of `std::is_same<X, Y>` and test it in a `constexr` Boolean
 context.
 
 ### Logical operations
 
-The traits `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
+The *traits* `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
 the basic logical operations with types:
 
 \snippet example/tutorial_snippets.cpp logical_operations0
 
 ### Eager and lazy evaluation
 
-> TODO aliases are eager, `meta::defer`, `meta::lazy` namespace.
+> TODO *aliases* are eager, `meta::defer`, `meta::lazy` namespace.
 
 ### Lambdas
 
-Lambda functions allow you to define Callables in place:
+Lambda functions allow you to define *Callable*s in place:
 
 \snippet example/tutorial_snippets.cpp lambda0
 
 ### Type lists
-
+F
 A list of types `Ts...` can be stored in the type `meta::list<Ts...>`. It provides a O(1)
 static member function `meta::list::size()` that returns the size of the list.
 
 \snippet example/tutorial_snippets.cpp type_list0
 
 As you can see, the `meta::front<List>`, `meta::back<List>`, and
-`meta::at_c<List, std::size_t>` aliases provide access to the elements of the list. The
-`meta::empty<List>` alias is `std::true_type` if the list is empty. The
-`meta::at<List, meta::size_t<N>>` alias differs from `meta::at_c` in that it takes a
+`meta::at_c<List, std::size_t>` *aliases* provide access to the elements of the list. The
+`meta::empty<List>` *alias* is `std::true_type` if the list is empty. The
+`meta::at<List, meta::size_t<N>>` *alias* differs from `meta::at_c` in that it takes a
 `meta::size_t<N>` (`std::integral_constant<std::size_t, N>`) instead of an integer:
 
 \snippet example/tutorial_snippets.cpp type_list1
@@ -178,13 +176,13 @@ elements, removing duplicates:
 
 \snippet example/tutorial_snippets.cpp type_list4
 
-To convert other type sequences into a `meta::list`, the utility trait
+To convert other type sequences into a `meta::list`, the utility *trait*
 `meta::as_list<Sequence>` is provided. For example:
 
 \snippet example/tutorial_snippets.cpp type_list5
 
 To use meta with your own data types you can specialize the
-`meta::extension::apply` trait for your own data type. For example,
+`meta::extension::apply` *trait* for your own data type. For example,
 to use meta with C++14 `std::integer_sequence`, you can:
 
 \snippet example/tutorial_snippets.cpp type_list6

--- a/doc/index.md
+++ b/doc/index.md
@@ -71,7 +71,7 @@ provides `_t` *alias templates* for all the *traits* in the standard library.
 libraries you may be familiar with, which make *traits* (aka metafunctions) the prime
 abstraction. The rest of this guide uses the term "alias" to mean "alias template".
 
-### *Callable*s
+### Callables
 
 A **Callable** is a class (it is not a template!) suitable for higher-order metaprogramming. It containts a nested *alias* called (by convention) `invoke`:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -73,7 +73,7 @@ abstraction. The rest of this guide uses the term "alias" to mean "alias templat
 
 ### Callables
 
-A **Callable** is a class (it is not a template!) suitable for higher-order metaprogramming. It containts a nested *alias* called (by convention) `invoke`:
+A *Callable* is a class (it is not a template!) suitable for higher-order metaprogramming. It containts a nested *alias* called (by convention) `invoke`:
 
 \snippet example/tutorial_snippets.cpp callable0
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,65 +34,66 @@ terminology and esoteric concepts.
 
 ## Tutorial
 
-The tutorial begins with a brief introduction to *trait*s, *alias*es, and *Callable*s.
-Then it moves to *trait* composition and currying. Finally, it covers type list algorithms
+The tutorial begins with a brief introduction to traits, aliases, and callables.
+Then it moves to trait composition and currying. Finally, it covers type list algorithms
 and algorithms for working on integer sequences.
 
 TODO This feels backwards. Algorithms come first. Everything else is in support of them.
 
 ### Traits
 
-*Traits* are class templates that have a nested type *alias* called (by convention) `type`.
+*Traits* are class templates that have a nested type alias called (by convention) `type`.
 For example,
 
 \snippet example/tutorial_snippets.cpp trait0
 
-is a *trait* taking an arbitrary number of types that always "returns" `void`. There are
-many familiar examples of *trait*s in the Standard Library; `std::remove_reference` and
+is a trait taking an arbitrary number of types that always "returns" `void`. There are
+many familiar examples of traits in the Standard Library; `std::remove_reference` and
 `std::is_void` to name two.
 
 ## Aliases
 
-An *alias* is a synonym for a type. C++11 introduced *alias templates*, which are names
-that refer to a family of types. *Alias templates* simplify template syntax and smooth
-out interface differences. Below is an example of an *alias template*:
+An *alias* is a synonym for a type. C++11 introduced alias *templates*, which are names
+that refer to a family of types. Alias templates simplify template syntax and smooth
+out interface differences. Below is an example of an alias template:
 
 \snippet example/tutorial_snippets.cpp trait1
 
 Notice how `t_t<int, double>` becomes a synonym for `void`. The C++14 standard library
-provides `_t` *alias templates* for all the *trait*s in the standard library.
+provides `_t` alias templates for all the traits in the standard library.
 
-*Meta* provides `meta::_t<T>`, which evaluates the *trait* `T` by aliasing the nested
-`T::type` *alias*. This allows us to alias the nested `type` of a *trait* as follows:
+*Meta* provides `meta::_t<T>`, which evaluates the trait `T` by aliasing the nested
+`T::type` alias. This allows us to alias the nested `type` of a trait as follows:
 
 \snippet example/tutorial_snippets.cpp trait2
 
-\note *Alias templates* have primacy in Meta. This is different from other metaprogramming
-libraries you may be familiar with, which make *trait*s (aka metafunctions) the prime
+\note Alias templates have primacy in Meta. This is different from other metaprogramming
+libraries you may be familiar with, which make traits (aka metafunctions) the prime
 abstraction. The rest of this guide uses the term "alias" to mean "alias template".
 
 ### Callables
 
-A *Callable* is a class (it is not a template!) suitable for higher-order metaprogramming. It containts a nested *alias* called (by convention) `invoke`:
+A *Callable* is a class (it is not a template!) suitable for higher-order metaprogramming. 
+It containts a nested alias called (by convention) `invoke`:
 
 \snippet example/tutorial_snippets.cpp callable0
 
-All of the algorithms that take "functions" as arguments expect *Callable*s instead of
-raw *alias*es.  *Meta* provides the `meta::invoke<F, Args...>` *alias* that evaluates the
-*Callable* `F` with the arguments `Args`:
+All of the algorithms that take "functions" as arguments expect Callables instead of
+raw aliases.  *Meta* provides the `meta::invoke<F, Args...>` alias that evaluates the
+Callable `F` with the arguments `Args`:
 
 \snippet example/tutorial_snippets.cpp callable1
 
-To turn an ordinary *trait* into a *Callable* *Meta* provides the `meta::quote<F>` *Callable*:
+To turn an ordinary trait into a *Callable* *Meta* provides the `meta::quote<F>` *Callable*:
 
 \snippet example/tutorial_snippets.cpp callable2
 
-Note that in the first case we create a *Callable* that evaluates to the *trait* itself,
-while in the second case we create a *Callable* that evaluates to the nested `type` of
-the *trait*.
+Note that in the first case we create a Callable that evaluates to the trait itself,
+while in the second case we create a Callable that evaluates to the nested `type` of
+the trait.
 
-When "quoting" a *trait*, it is often desirable for the resulting *Callable* to refer to
-the nested `type` instead of the *trait* itself. For that we can use `meta::quote_trait`.
+When "quoting" a trait, it is often desirable for the resulting Callable to refer to
+the nested `type` instead of the trait itself. For that we can use `meta::quote_trait`.
 Consider:
 
 \snippet example/tutorial_snippets.cpp callable3
@@ -100,62 +101,62 @@ Consider:
 Notice that `meta::quote<std::add_pointer_t>` and `meta::quote_trait<std::add_pointer>`
 mean the same thing.
 
-\note You may wonder what advantage *Callable*s have over *alias templates*. A *Callable* is a *type* that represents a computation (it is the metaprogramming 
+\note You may wonder what advantage Callables have over alias templates. A Callable is a *type* that represents a computation (it is the metaprogramming 
 analogue to a functor class which has a call operator `operator()(...)`). Much of Meta revolves around types and the computation of types. Sometimes it's desirable to compute a computation, or to use a
 computation as an argument to another computation. In those cases, it's very handy for
 computations to themselves be types and not templates.
 
 ### Composition
 
-Multiple *Callable*s can be composed into a single *Callable* using
-`meta::compose<F0, F1, ..., FN>`, which names a new *Callable* that performs
+Multiple Callables can be composed into a single Callable using
+`meta::compose<F0, F1, ..., FN>`, which names a new Callable that performs
 `F0(F1(...(FN(Args...))))`:
 
 \snippet example/tutorial_snippets.cpp composition0
 
 ### Partial function application
 
-You can turn a *Callable* expecting *N* arguments into a *Callable* expecting *N-M*
+You can turn a Callable expecting *N* arguments into a Callable expecting *N-M*
 arguments by binding *M* arguments to the front or the back of its argument list. You can
-use `meta::bind_front` and `meta::bind_back` for that. Below we create a *Callable*
-that tests whether a type is `float` by reusing the `std::is_same` *trait*:
+use `meta::bind_front` and `meta::bind_back` for that. Below we create a Callable
+that tests whether a type is `float` by reusing the `std::is_same` trait:
 
 \snippet example/tutorial_snippets.cpp partial_application0
 
-\note If `std::is_same` is a *trait*, why did we use `meta::quote` instead of
-`meta::quote_trait`? In this case, it makes no difference. In addition to being a *trait*,
+\note If `std::is_same` is a trait, why did we use `meta::quote` instead of
+`meta::quote_trait`? In this case, it makes no difference. In addition to being a trait,
 `std::is_same<X, Y>` inherits from `std::integral_constant<bool, true-or-false>` so we
 can construct an instance of `std::is_same<X, Y>` and test it in a `constexr` Boolean
 context.
 
 ### Logical operations
 
-The *trait*s `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
+The traits `meta::if_`, `meta::and_`, `meta::or_`, and `meta::not_` cover
 the basic logical operations with types:
 
 \snippet example/tutorial_snippets.cpp logical_operations0
 
 ### Eager and lazy evaluation
 
-> TODO *alias*es are eager, `meta::defer`, `meta::lazy` namespace.
+> TODO aliases are eager, `meta::defer`, `meta::lazy` namespace.
 
 ### Lambdas
 
-Lambda functions allow you to define *Callable*s in place:
+Lambda functions allow you to define Callables in place:
 
 \snippet example/tutorial_snippets.cpp lambda0
 
 ### Type lists
-F
+
 A list of types `Ts...` can be stored in the type `meta::list<Ts...>`. It provides a O(1)
 static member function `meta::list::size()` that returns the size of the list.
 
 \snippet example/tutorial_snippets.cpp type_list0
 
 As you can see, the `meta::front<List>`, `meta::back<List>`, and
-`meta::at_c<List, std::size_t>` *alias*es provide access to the elements of the list. The
-`meta::empty<List>` *alias* is `std::true_type` if the list is empty. The
-`meta::at<List, meta::size_t<N>>` *alias* differs from `meta::at_c` in that it takes a
+`meta::at_c<List, std::size_t>` aliases provide access to the elements of the list. The
+`meta::empty<List>` alias is `std::true_type` if the list is empty. The
+`meta::at<List, meta::size_t<N>>` alias differs from `meta::at_c` in that it takes a
 `meta::size_t<N>` (`std::integral_constant<std::size_t, N>`) instead of an integer:
 
 \snippet example/tutorial_snippets.cpp type_list1
@@ -176,13 +177,13 @@ elements, removing duplicates:
 
 \snippet example/tutorial_snippets.cpp type_list4
 
-To convert other type sequences into a `meta::list`, the utility *trait*
+To convert other type sequences into a `meta::list`, the utility trait
 `meta::as_list<Sequence>` is provided. For example:
 
 \snippet example/tutorial_snippets.cpp type_list5
 
 To use meta with your own data types you can specialize the
-`meta::extension::apply` *trait* for your own data type. For example,
+`meta::extension::apply` trait for your own data type. For example,
 to use meta with C++14 `std::integer_sequence`, you can:
 
 \snippet example/tutorial_snippets.cpp type_list6


### PR DESCRIPTION
Some changes for notation uniformity to cleary distinguis **traits**, **aliases** and **Callable** (maybee its too noisy, however its consistent ;-)

Some small typos...