### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -12,7 +12,7 @@ It is released under the Boost Software License and it is header only; that is,
 to compile with meta you just have to:
 
 ~~~~~~~{.cpp}
-#include <meta/meta.hpp>
+# include <meta/meta.hpp>
 ~~~~~~~
 
 --------------------------------------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
