### PR TITLE
Don't workaround MSVC bugs when not needed

### DIFF
--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -39,9 +39,13 @@
 
 #elif defined(_MSC_VER)
 #define META_HAS_MAKE_INTEGER_SEQ 1
-#define META_WORKAROUND_MSVC_702792 // Fixed for VS2019, possibly 16.0?
-#define META_WORKAROUND_MSVC_703656 // Fixed for VS2019 16.0
-#define META_WORKAROUND_MSVC_756112 // fold expression + alias templates in template argument
+#if _MSC_VER < 1921
+#define META_WORKAROUND_MSVC_756112 // fold expression + alias templates in template argument (Fixed in next VS2019 toolset update)
+#if _MSC_VER < 1920
+#define META_WORKAROUND_MSVC_702792 // Fixed in VS2019 Preview 2
+#define META_WORKAROUND_MSVC_703656 // Fixed in VS2019 Preview 2
+#endif // _MSC_VER < 1920
+#endif // _MSC_VER < 1921
 
 #elif defined(__GNUC__)
 #define META_WORKAROUND_GCC_86356 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86356


### PR DESCRIPTION
702792 and 703656 are fixed in VS2019 Preview 2. 756112 has been fixed as well, but won't hit a release until the first update.