### PR TITLE
Replace std::is_void by std::decay

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -49,7 +49,7 @@ For example,
 
 is a trait taking an arbitrary number of types that always "returns" `void`. There are
 many familiar examples of traits in the Standard Library; `std::remove_reference` and
-`std::is_void` to name two.
+`std::decay` to name two.
 
 ## Aliases
 


### PR DESCRIPTION
Currently `std::is_void` is used as an example of type trait.
But `std::is_void` contains `::value` instead of `::type`,
thus not fitting with the definition of "trait."