### PR TITLE
Fix reverse_fold without concepts

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1600,7 +1600,7 @@ namespace meta
 #else
         template <typename Head, typename... Tail, typename State, typename Fn>
         struct reverse_fold_<list<Head, Tail...>, State, Fn>
-          : lazy::invoke<compose1_<Fn, Head>, reverse_fold_<list<Tail...>, State, Fn>>
+          : lazy::invoke<Fn, Head, _t<reverse_fold_<list<Tail...>, State, Fn>>>
         {
         };
 #endif


### PR DESCRIPTION
I believe there's an error in the `reverse_fold` implementation in case `META_CONCEPT` is not set. `compose1_` as defined by `fold` »unwraps« the functor's second parameter and passes it on as the first argument to the function. Where `compose1_` is used in the implementation of `reverse_fold`, I believe we **don't** want to »unwrap« the functor's second parameter and pass it on as the first function argument. Anyway, that's how I interpret `Fun(A_N, State_N+1)` in the documentation.

Without this change, I get
```
In file included from examples/calc/calc.cc:1:
meta/include/meta/meta.hpp:141:5: error: no type named 'type' in 'meta::detail::reverse_fold_<meta::list<…>, meta::list<>, (anonymous namespace)::CollectProductions<(anonymous namespace)::Expr> >'
    using _t = typename T::type;
    ^~~~~
```
My compiler is
```
$ c++ --version
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```